### PR TITLE
Added libresolv library

### DIFF
--- a/OoyalaSDK/4.3.1/OoyalaSDK.podspec
+++ b/OoyalaSDK/4.3.1/OoyalaSDK.podspec
@@ -16,6 +16,6 @@ s.source	= { :git => "https://github.com/ooyala/ios-sample-apps.git", :tag => "v
 s.vendored_frameworks	= "vendor/Ooyala/OoyalaSDK-iOS/OoyalaSDK.framework"
 
 s.frameworks	= "CoreMedia", "QuartzCore", "AVFoundation", "MediaPlayer", "MediaAccessibility", "SystemConfiguration"
-s.libraries	= "z", "xml2", "c++"
+s.libraries	= "z", "xml2", "c++", "resolv"
 
 end


### PR DESCRIPTION
This was needed to make the ooyala sdk compile on an iOS device. Has anyone else run into this? Without this, I would get an undefined symbol: _res_9_init

It compiled for the simulator fine without it.