### PR TITLE
Updated OoyalaSDK podspec to point to the correct final relase tag for v4.9.0

### DIFF
--- a/OoyalaSDK/4.9.0/OoyalaSDK.podspec
+++ b/OoyalaSDK/4.9.0/OoyalaSDK.podspec
@@ -11,7 +11,7 @@ s.author	= { "Ooyala Playback Mobile" => "playback-app@ooyala.com" }
 
 s.platform	= :ios, "7.0"
 
-s.source	= { :git => "https://github.com/ooyala/ios-sample-apps.git", :tag => "v4.9.0"}
+s.source	= { :git => "https://github.com/ooyala/ios-sample-apps.git", :tag => "v4.9.0_GA"}
 
 s.vendored_frameworks	= "vendor/Ooyala/OoyalaSDK-iOS/OoyalaSDK.framework"
 


### PR DESCRIPTION
v4.9.0 isn't a tag in https://github.com/ooyala/ios-sample-apps, but v4.9.0_GA is. This matches the format of the tag used for the previous v4.8.0 release.