### PR TITLE
Fixed framework name in podspec for tvOS integration

### DIFF
--- a/OoyalaSDK/4.21.0/OoyalaSDK.podspec
+++ b/OoyalaSDK/4.21.0/OoyalaSDK.podspec
@@ -15,7 +15,7 @@ s.tvos.deployment_target	= "9.0"
 s.source	= { :git => "https://github.com/ooyala/ios-sample-apps.git", :tag => "v4.21.0_GA"}
 
 s.ios.vendored_frameworks	= "vendor/Ooyala/OoyalaSDK-iOS/OoyalaSDK.framework"
-s.tvos.vendored_frameworks	= "vendor/Ooyala/OoyalaSDK-tvOS/OoyalaTVSDK.framework"
+s.tvos.vendored_frameworks	= "vendor/Ooyala/OoyalaSDK-tvOS/OoyalaSDK.framework"
 
 s.frameworks	= "CoreMedia", "QuartzCore", "AVFoundation", "MediaPlayer", "MediaAccessibility", "SystemConfiguration","AVKit","JavaScriptCore"
 s.libraries	= "z", "xml2", "c++"


### PR DESCRIPTION
tvOS integration doesn't work through CocoaPods because the path to the framework is not valid. The framework name doesn't match what is listed in the podspec.